### PR TITLE
ggdesplot(): leave cells with a missing value empty

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # desplot 1.11 ()
 
+* `ggdesplot()` now leaves cells with a missing value empty, as `desplot()` does. Previously they were filled with the ggplot2 default grey, which lies inside the range of the default red-gray-blue scale and so looked like a mid-range value. (P.Schmidt)
+
 * `ggdesplot()` no longer draws a spurious `no_color` legend when `text` or `num` is used without `col`. (P.Schmidt)
 
 * `ggdesplot()` now facets on every conditioning variable in a formula such as `yield ~ col*row | site + rep`. Previously only the first was used and the others were silently dropped, overplotting cells. (P.Schmidt)

--- a/R/ggdesplot.R
+++ b/R/ggdesplot.R
@@ -482,17 +482,21 @@ ggdesplot <- function(data,
     out <- out + 
       facet_wrap(panel.string, scales="free")
   
+  # Note, cells with a missing value are left empty instead of being filled
+  # with the ggplot2 default grey50, which is hard to tell from the lightgray
+  # midpoint of RedGrayBlue. The lattice version leaves such cells empty too.
   if(fill.type=="num")
     out <- out +
     #geom_tile(aes_string(fill = fill.string)) +
     geom_tile(aes(fill = .data[[fill.string]])) +
-    scale_fill_gradientn(colours=col.regions, guide="colorbar")
+    scale_fill_gradientn(colours=col.regions, guide="colorbar",
+                         na.value="transparent")
   
   if(fill.type=="factor")
     out <- out +
     #geom_tile(aes_string(fill = fill.string)) +
     geom_tile(aes(fill = .data[[fill.string]])) +
-    scale_fill_manual(values=col.regions)
+    scale_fill_manual(values=col.regions, na.value="transparent")
   
   if(has.out1)
     out <- out +

--- a/tests/testthat/test_ggdesplot_fixes.R
+++ b/tests/testthat/test_ggdesplot_fixes.R
@@ -44,3 +44,23 @@ test_that("ggdesplot single conditioning variable keeps its panel labels", {
   p <- suppressWarnings(ggdesplot(besag.met, yield ~ col * row | county))
   expect_equal(levels(p$data$.panel), paste0("C", 1:6))
 })
+
+test_that("ggdesplot leaves a cell with a missing value empty", {
+  # 4x4 field with a hole at col 2 / row 2, once numeric and once a factor
+  hole <- data.frame(
+    col = rep(1:4, times = 4),
+    row = rep(1:4, each = 4),
+    yield = c(1:5, NA, 7:16),
+    B = factor(c(rep("b1", 5), NA, rep("b2", 10)))
+  )
+
+  fill_num <- ggplot2::layer_data(ggdesplot(hole, yield ~ col * row), 1)$fill
+  expect_equal(sum(fill_num == "transparent"), 1L)
+  # the guard: the other 15 cells still get a real colour from col.regions,
+  # so the empty cell comes from the missing value and not from a broken scale
+  expect_equal(length(unique(fill_num[fill_num != "transparent"])), 15L)
+
+  fill_fac <- ggplot2::layer_data(ggdesplot(hole, B ~ col * row), 1)$fill
+  expect_equal(sum(fill_fac == "transparent"), 1L)
+  expect_equal(length(unique(fill_fac[fill_fac != "transparent"])), 2L)
+})


### PR DESCRIPTION
## Problem

`desplot()` leaves a cell whose value is missing empty, `ggdesplot()` fills it with the
ggplot2 default `grey50`. That is not a neutral colour here: the default `RedGrayBlue` scale
runs `firebrick` -> `lightgray` -> `#375997`, so grey is what the *middle of the data range*
looks like, and a hole in the field reads as an average value rather than as no data. With a
factor response the grey cell is a fill that the key has no entry for.

## Reproducer

`besag.met` is the dataset the vignette uses. 36 of its 1188 plots have no yield, and the gg
path drew every one of them grey (desplot 1.11, `b18cfbb`):

```r
data(besag.met, package = "agridat")
f <- ggplot2::layer_data(ggdesplot(besag.met, yield ~ col * row | county), 1)$fill

sum(is.na(besag.met$yield))    #> 36
sum(f == "grey50")             #> 36    on main
sum(f == "transparent")        #> 36    with this branch

desplot(besag.met, yield ~ col * row | county)   # the same cells are empty here
```

The grey is hard to tell from data in that map, because the mid-range cells are themselves
grey (`#D3D1D1` and `#C1C5CC` here).

The vignette draws this dataset with `desplot()` rather than `ggdesplot()`, so no rendered
documentation changes.

## Before / after

`ggdesplot(besag.met, yield ~ col * row | county)`, rendered against `main` and against this
branch. There are six missing plots in each of the six counties, so every panel is affected.

**Before** (`main`), 36 plots filled `grey50`:

<img width="1200" height="850" alt="besag_BEFORE" src="https://github.com/user-attachments/assets/d0f8656c-5c49-47a6-934a-3aceb9558f24" />

**After** (this branch), the same 36 plots left empty:

<img width="1200" height="850" alt="besag_AFTER" src="https://github.com/user-attachments/assets/98f90fd5-6af3-4ec7-b12e-4610bc0c3bda" />

## Fix

`na.value = "transparent"` on both fill scales, `scale_fill_gradientn()` for a numeric
response and `scale_fill_manual()` for a factor. The gg panel background is
`element_blank()`, so a transparent cell comes out white, which is what the lattice path
draws. The observed cells are unchanged, so the fix touches the missing cells only and does
not shift the scale.

Regression test added to `tests/testthat/test_ggdesplot_fixes.R`. It covers both the numeric
and the factor branch on a small synthetic field, and it also pins that the remaining cells
still get a real colour, so an empty cell cannot come from a broken scale instead. On `main`
it fails (4 failures, the 29 existing expectations pass), with the fix the suite is 33
passing, 0 failures, 0 warnings. `R CMD check --no-manual` including the vignette rebuild is
`Status: OK`.

*Prepared with the help of an AI coding assistant; the reproducers above were run and
verified locally.*
